### PR TITLE
Update GroupGridView.php

### DIFF
--- a/GroupGridView.php
+++ b/GroupGridView.php
@@ -293,8 +293,10 @@ class GroupGridView extends CGridView {
     * @param mixed $row
     * @param mixed $data
     */
-    private function getDataCellContent($column, $data, $row)
+    public static function getDataCellContent($column, $array_data, $row)
     {
+		$data = $array_data[$row];
+		
         if($column->value!==null)
             $value=$column->evaluateExpression($column->value, array('data'=>$data,'row'=>$row));
         else if($column->name!==null)


### PR DESCRIPTION
Fix: Providing right context for the evaluation of the column value.
Although the code is well copied from renderDataCell in framework/zii/widgets/grid/CGridColumn.php#135, the data variable is not in the same scope. 

First line in original code is missing: $data=$this->grid->dataProvider->data[$row];
I added a similar one.
